### PR TITLE
Image Download Optimization - For Review

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.h
+++ b/AFNetworking/UIImageView+AFNetworking.h
@@ -28,10 +28,11 @@
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
 #import <UIKit/UIKit.h>
 
+void enqueueImageDownloadRequest(NSURL* url);
+
 @interface AFImageCache : NSCache
-- (UIImage *)cachedImageForRequest:(NSURLRequest *)request;
-- (void)cacheImage:(UIImage *)image
-        forRequest:(NSURLRequest *)request;
+- (UIImage*) cachedImageForRequest:(NSURLRequest*)request;
+- (void) cacheImage:(UIImage*)image forKey:(NSString*)request;
 @end
 
 /**
@@ -46,7 +47,7 @@
 
  @param url The URL used for the image request.
  */
-- (void)setImageWithURL:(NSURL *)url;
+- (void) setImageWithURL:(NSURL*)url;
 
 /**
  Creates and enqueues an image request operation, which asynchronously downloads the image from the specified URL. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
@@ -56,8 +57,7 @@
  @param url The URL used for the image request.
  @param placeholderImage The image to be set initially, until the image request finishes. If `nil`, the image view will not change its image until the image request finishes.
  */
-- (void)setImageWithURL:(NSURL *)url
-       placeholderImage:(UIImage *)placeholderImage;
+- (void) setImageWithURL:(NSURL*)url placeholderImage:(UIImage*)placeholderImage;
 
 /**
  Creates and enqueues an image request operation, which asynchronously downloads the image with the specified URL request object. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
@@ -77,9 +77,9 @@
 /**
  Cancels any executing image request operation for the receiver, if one exists.
  */
-- (void)cancelImageRequestOperation;
+- (void) cancelImageRequestOperationForKey:(NSString*)key;
 
-+ (AFImageCache *)af_sharedImageCache;
++ (AFImageCache*) af_sharedImageCache;
 
 @end
 

--- a/AFNetworking/UIImageView+AFNetworking.h
+++ b/AFNetworking/UIImageView+AFNetworking.h
@@ -28,6 +28,9 @@
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
 #import <UIKit/UIKit.h>
 
+/**
+ This function call is used to place an image download request directly into the queue without an UIImageView depending on it at the time.
+ */
 void enqueueImageDownloadRequest(NSURL* url);
 
 @interface AFImageCache : NSCache

--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -180,22 +180,6 @@ static void(^preloadingCompletionBlock)(AFHTTPRequestOperation*, id) = ^(AFHTTPR
 };
 
 void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage* placeholderImage, void (^success)(NSURLRequest*, NSHTTPURLResponse*, UIImage*), void (^failure)(NSURLRequest* request, NSHTTPURLResponse* response, NSError* error)) {
-    UIImage* cachedImage = [[UIImageView af_sharedImageCache] cachedImageForRequest:urlRequest];
-    NSString* key = [urlRequest.URL absoluteString];
-    if (!key) return;
-    
-    if (cachedImage) {
-        if (success) {
-            success(nil, nil, cachedImage);
-        } else {
-            self.image = cachedImage;
-        }
-        return;
-    }
-    
-    if (placeholderImage) {
-        self.image = placeholderImage;
-    }
     
     /**
      The default is block behaves like a pre-loading request unless there is a specific UIImageView making the request.
@@ -218,6 +202,23 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
     
     AFImageRequestOperation* oldRequestOperation = [UIImageView af_operationForKey:key];
     @synchronized (oldRequestOperation) {
+        UIImage* cachedImage = [[UIImageView af_sharedImageCache] cachedImageForRequest:urlRequest];
+        NSString* key = [urlRequest.URL absoluteString];
+        if (!key) return;
+        
+        if (cachedImage) {
+            if (success) {
+                success(nil, nil, cachedImage);
+            } else {
+                self.image = cachedImage;
+            }
+            return;
+        }
+        
+        if (placeholderImage) {
+            self.image = placeholderImage;
+        }
+    
         AFImageRequestOperation* requestOperation = oldRequestOperation ?: [[AFImageRequestOperation alloc] initWithRequest:urlRequest];
         #ifdef _AFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
         requestOperation.allowsInvalidSSLCertificate = YES;

--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -180,6 +180,8 @@ static void(^preloadingCompletionBlock)(AFHTTPRequestOperation*, id) = ^(AFHTTPR
 };
 
 void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage* placeholderImage, void (^success)(NSURLRequest*, NSHTTPURLResponse*, UIImage*), void (^failure)(NSURLRequest* request, NSHTTPURLResponse* response, NSError* error)) {
+    NSString* key = [urlRequest.URL absoluteString];
+    if (!key) return;
     
     /**
      The default is block behaves like a pre-loading request unless there is a specific UIImageView making the request.
@@ -203,8 +205,6 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
     AFImageRequestOperation* oldRequestOperation = [UIImageView af_operationForKey:key];
     @synchronized (oldRequestOperation) {
         UIImage* cachedImage = [[UIImageView af_sharedImageCache] cachedImageForRequest:urlRequest];
-        NSString* key = [urlRequest.URL absoluteString];
-        if (!key) return;
         
         if (cachedImage) {
             if (success) {
@@ -224,7 +224,7 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
         requestOperation.allowsInvalidSSLCertificate = YES;
         #endif
         if (requestOperation.isCompleted) { /* We missed the boat on getting our request in; simulate it */
-            uiImageViewCompletionBlock(requestOperation, [[UIImageView af_sharedImageCache] cachedImageForRequest:requestOperation.request])
+            uiImageViewCompletionBlock(requestOperation, [[UIImageView af_sharedImageCache] cachedImageForRequest:requestOperation.request]);
         } else {
             if (self) requestOperation.queuePriority = NSOperationQueuePriorityVeryHigh; /* There is a cell making the request, it's more important */
             [requestOperation addCompletionBlock:uiImageViewCompletionBlock];

--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -143,6 +143,7 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
     Class cls = [UIImageView class];
     UIImage* cachedImage = [[cls af_sharedImageCache] cachedImageForRequest:urlRequest];
     NSString* key = [urlRequest.URL absoluteString];
+    if (!key) return;
     
     if (cachedImage) {
         if (success) {

--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -203,6 +203,7 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
     }
     
     AFImageRequestOperation* oldRequestOperation = [UIImageView af_operationForKey:key];
+    AFImageRequestOperation* requestOperation;
     @synchronized (oldRequestOperation) {
         UIImage* cachedImage = [[UIImageView af_sharedImageCache] cachedImageForRequest:urlRequest];
         
@@ -219,7 +220,7 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
             self.image = placeholderImage;
         }
     
-        AFImageRequestOperation* requestOperation = oldRequestOperation ?: [[AFImageRequestOperation alloc] initWithRequest:urlRequest];
+        requestOperation = oldRequestOperation ?: [[AFImageRequestOperation alloc] initWithRequest:urlRequest];
         #ifdef _AFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
         requestOperation.allowsInvalidSSLCertificate = YES;
         #endif

--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -236,6 +236,7 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
         }
         
         requestOperation = oldRequestOperation ?: [[AFImageRequestOperation alloc] initWithRequest:urlRequest];
+        self.af_imageRequestOperation.queuePriority = NSOperationQueuePriorityNormal;
         self.af_imageRequestOperation = requestOperation;
         #ifdef _AFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
         requestOperation.allowsInvalidSSLCertificate = YES;
@@ -243,7 +244,11 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
         if (requestOperation.isCompleted) { /* We missed the boat on getting our request in; simulate it */
             uiImageViewCompletionBlock(requestOperation, [[UIImageView af_sharedImageCache] cachedImageForRequest:requestOperation.request]);
         } else {
-            if (self) requestOperation.queuePriority = NSOperationQueuePriorityVeryHigh; /* There is a cell making the request, it's more important */
+            if (self) {
+                requestOperation.queuePriority = NSOperationQueuePriorityVeryHigh; /* There is a cell making the request, it's more important */
+            } else {
+                requestOperation.queuePriority = NSOperationQueuePriorityNormal;
+            }
             [requestOperation addCompletionBlock:uiImageViewCompletionBlock];
         }
     }

--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -199,7 +199,7 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
             } else if (failure) {
                 failure(op.request, op.response, response);
             }
-        }
+        };
     }
     
     AFImageRequestOperation* oldRequestOperation = [UIImageView af_operationForKey:key];

--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -206,7 +206,6 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
     AFImageRequestOperation* requestOperation;
     @synchronized (oldRequestOperation) {
         UIImage* cachedImage = [[UIImageView af_sharedImageCache] cachedImageForRequest:urlRequest];
-        
         if (cachedImage) {
             if (success) {
                 success(nil, nil, cachedImage);
@@ -215,11 +214,10 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
             }
             return;
         }
-        
         if (placeholderImage) {
             self.image = placeholderImage;
         }
-    
+        
         requestOperation = oldRequestOperation ?: [[AFImageRequestOperation alloc] initWithRequest:urlRequest];
         #ifdef _AFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
         requestOperation.allowsInvalidSSLCertificate = YES;
@@ -231,11 +229,9 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
             [requestOperation addCompletionBlock:uiImageViewCompletionBlock];
         }
     }
-    
     if (!oldRequestOperation) { /* operations can only be started once, and we need the standard completion block to kick in */
-            [requestOperation setCompletionBlockWithSuccess:standardCompletionBlock failure:standardCompletionBlock];
-            [[UIImageView af_sharedImageRequestOperationQueue] addOperation:requestOperation];
-        }
+        [requestOperation setCompletionBlockWithSuccess:standardCompletionBlock failure:standardCompletionBlock];
+        [[UIImageView af_sharedImageRequestOperationQueue] addOperation:requestOperation];
     }
 }
 


### PR DESCRIPTION
Ultimately what we're trying to accomplish is two fold.

First we want to be able to submit pre-loading requests for images which have yet to appear.
Second when the same url is requested multiple times, we want all the work from the first time to be preserved (but the image still has to arrive for the new caller as well).

Additionally:  
pre-loading requests should become owned by a UIImageView when that view now needs the image.
UIImageView requests that move off the screen should still be worked on
