### PR TITLE
Support the use of dummy image views to assign some logic to end of image loading

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -200,7 +200,7 @@ void setImageWithURLRequest(UIImageView* self, NSURLRequest* urlRequest, UIImage
         __weak typeof(self) weakSelf = self;
         uiImageViewCompletionBlock = ^(AFHTTPRequestOperation* op, id response) {
             __strong typeof(self) strongSelf = weakSelf;
-            if (op == strongSelf.af_imageRequestOperation) {
+            if (op == strongSelf.af_imageRequestOperation || !strongSelf) { /* if the view dealloc'd we will still call to the blocks */
                 strongSelf.af_imageRequestOperation = nil;
                 dispatch_async(dispatch_get_main_queue(), ^{ /* request was performed on a background thread */
                     __strong typeof(self) strongSelf = weakSelf;


### PR DESCRIPTION
Given that an image view can request multiple different images it was necessary to check that request finishing was the final request, but this leads to incompatibility with dummy views which are `dealloc`'d almost immediately.  We will call the completion handlers in this case so that someone may perform some logic on the completion of the request.
